### PR TITLE
fix: remove dollar sign, installation step, and use npx for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,12 @@ Linguify translation files manager
 
 ## Getting started
 
-### Installation
-
-Via npm
-```bash
-$ npm install linguify --save-dev
-```
-
-Via pnpm
-```bash
-$ pnpm add -D linguify
-```
-
-Via yarn
-```bash
-$ yarn add -D linguify
-```
-
 ### Usage
 
 1. Initiate Linguify with the `init` command
 
 ```bash
-$ linguify init
+$ npx linguify init
 ```
 
  * This will create `linguify.config.json` file at the root of your project.
@@ -48,19 +31,19 @@ $ linguify init
 3. Start linguify.
 
 ```bash
-$ linguify
+$ npx linguify
 ```
 
 or
 
 ```bash
-$ linguify start
+$ npx linguify start
 ```
 
  * Linguify server port can be changed using `-p` or `--port` option following the desired port
 
 ```bash
-$ linguify -p 3000
+$ npx linguify -p 3000
 ```
 
  * Note: Updating `linguify.config.json` while Linguify runs requires restarting it before affecting it.
@@ -74,7 +57,7 @@ It uses `defaultLocale` as the base of translations and namespaces, and copies m
 the `sync` operation happenes everytime Linguify starts, to sync translations manually you can use `sync` command.
 
 ```bash
-$ linguify sync
+$ npx linguify sync
 ```
 
 <hr />

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Linguify translation files manager
 1. Initiate Linguify with the `init` command
 
 ```bash
-$ npx linguify init
+npx linguify init
 ```
 
  * This will create `linguify.config.json` file at the root of your project.
@@ -31,19 +31,19 @@ $ npx linguify init
 3. Start linguify.
 
 ```bash
-$ npx linguify
+npx linguify
 ```
 
 or
 
 ```bash
-$ npx linguify start
+npx linguify start
 ```
 
  * Linguify server port can be changed using `-p` or `--port` option following the desired port
 
 ```bash
-$ npx linguify -p 3000
+npx linguify -p 3000
 ```
 
  * Note: Updating `linguify.config.json` while Linguify runs requires restarting it before affecting it.
@@ -57,7 +57,7 @@ It uses `defaultLocale` as the base of translations and namespaces, and copies m
 the `sync` operation happenes everytime Linguify starts, to sync translations manually you can use `sync` command.
 
 ```bash
-$ npx linguify sync
+npx linguify sync
 ```
 
 <hr />


### PR DESCRIPTION
If the command "linguify" is not installed system-wide, the readme instructions will not work. Therefore you have to either install globally or use npx, and I think the latter is better.