### PR TITLE
Keep the output json files formatted by adding indentation

### DIFF
--- a/lib/syncNamespaces.ts
+++ b/lib/syncNamespaces.ts
@@ -45,7 +45,7 @@ export const syncNamespaces = () => {
       let json: DynamicObject = {}
       try {
         json = clear(JSON.parse(file), { skipFirstDepth: true })
-        writeFileSync(path, JSON.stringify(json))
+        writeFileSync(path, JSON.stringify(json, null, 2))
       } catch {
         writeFileSync(path, '{}')
       }
@@ -60,7 +60,7 @@ export const syncNamespaces = () => {
         let json: DynamicObject = {}
         try {
           json = clear(JSON.parse(file))
-          writeFileSync(path, JSON.stringify(json))
+          writeFileSync(path, JSON.stringify(json, null, 2))
         } catch {
           writeFileSync(path, '{}')
         }
@@ -74,21 +74,21 @@ export const syncNamespaces = () => {
         const path = getPath(`${locale}.json`)
         try {
           const json = clear(getFileJson(`${locale}.json`), { skipFirstDepth: true })
-          writeFileSync(path, JSON.stringify(_.defaultsDeep(json, nsKeys)))
+          writeFileSync(path, JSON.stringify(_.defaultsDeep(json, nsKeys), null, 2))
         } catch {
-          writeFileSync(path, JSON.stringify(nsKeys))
+          writeFileSync(path, JSON.stringify(nsKeys, null, 2))
         }
       } else {
         Object.keys(nsKeys).forEach(ns => {
           const path = getPath(locale, ns)
           if (!existsSync(path)) {
-            return writeFileSync(path, JSON.stringify({ ...nsKeys[ns] }))
+            return writeFileSync(path, JSON.stringify({ ...nsKeys[ns] }, null, 2))
           }
           try {
             const json = clear(getNamespaceJson(locale, ns))
-            writeFileSync(path, JSON.stringify(_.defaultsDeep(json, { ...nsKeys[ns] })))
+            writeFileSync(path, JSON.stringify(_.defaultsDeep(json, { ...nsKeys[ns] }), null, 2))
           } catch {
-            writeFileSync(path, JSON.stringify({ ...nsKeys[ns] }))
+            writeFileSync(path, JSON.stringify({ ...nsKeys[ns] }, null, 2))
           }
         })
       }

--- a/src/server/controllers/key.controller.ts
+++ b/src/server/controllers/key.controller.ts
@@ -46,9 +46,9 @@ export const createKey: RequestHandler = (req, res) => {
     if (config.useSingleFile) {
       const file = getFileJson(`${config.defaultLocale}.json`)
       file[name] = _.merge(defaultJson, defaultUnflattened)
-      writeFileSync(getPath(`${config.defaultLocale}.json`), JSON.stringify(file))
+      writeFileSync(getPath(`${config.defaultLocale}.json`), JSON.stringify(file, null, 2))
     } else {
-      writeFileSync(getPath(config.defaultLocale, name), JSON.stringify(_.merge(defaultJson, defaultUnflattened)))
+      writeFileSync(getPath(config.defaultLocale, name), JSON.stringify(_.merge(defaultJson, defaultUnflattened), null, 2))
     }
 
     // // adding to other languages
@@ -58,14 +58,14 @@ export const createKey: RequestHandler = (req, res) => {
         const json = getNamespaceJson(locale, name)
         const unflattened = unflatten({ [key]: translations[locale] || value })
         file[name] = _.merge(json, unflattened)
-        writeFileSync(getPath(`${locale}.json`), JSON.stringify(file))
+        writeFileSync(getPath(`${locale}.json`), JSON.stringify(file, null, 2))
         result.translations.push({ [locale]: value })
       })
     } else {
       otherLocales.forEach(locale => {
         const json = getNamespaceJson(locale, name)
         const unflattened = unflatten({ [key]: translations[locale] || value })
-        writeFileSync(getPath(locale, name), JSON.stringify(_.merge(json, unflattened)))
+        writeFileSync(getPath(locale, name), JSON.stringify(_.merge(json, unflattened), null, 2))
         result.translations.push({ [locale]: value })
       })
     }
@@ -124,9 +124,9 @@ export const updateKey: RequestHandler = (req, res) => {
     if (config.useSingleFile) {
       const file = getFileJson(`${config.defaultLocale}.json`)
       file[name] = _.merge(newJson, defaultUnflattened)
-      writeFileSync(getPath(`${config.defaultLocale}.json`), JSON.stringify(file))
+      writeFileSync(getPath(`${config.defaultLocale}.json`), JSON.stringify(file, null, 2))
     } else {
-      writeFileSync(getPath(config.defaultLocale, name), JSON.stringify(_.merge(newJson, defaultUnflattened)))
+      writeFileSync(getPath(config.defaultLocale, name), JSON.stringify(_.merge(newJson, defaultUnflattened), null, 2))
     }
 
     // modifing to other languages
@@ -138,7 +138,7 @@ export const updateKey: RequestHandler = (req, res) => {
         _.unset(json, oldKey)
         json = clear(json)
         file[name] = _.merge(json, unflattened)
-        writeFileSync(getPath(`${locale}.json`), JSON.stringify(file))
+        writeFileSync(getPath(`${locale}.json`), JSON.stringify(file, null, 2))
         result.translations.push({ [locale]: value })
       })
     } else {
@@ -147,7 +147,7 @@ export const updateKey: RequestHandler = (req, res) => {
         _.unset(json, oldKey)
         json = clear(json)
         const unflattened = unflatten({ [key]: translations[locale] || value })
-        writeFileSync(getPath(locale, name), JSON.stringify(_.merge(json, unflattened)))
+        writeFileSync(getPath(locale, name), JSON.stringify(_.merge(json, unflattened), null, 2))
         result.translations.push({ [locale]: value })
       })
     }
@@ -186,13 +186,13 @@ export const deleteKeys: RequestHandler = (req, res) => {
         let json = getNamespaceJson(locale, name)
         keys.forEach(k => _.unset(json, k))
         file[name] = clear(json)
-        writeFileSync(getPath(`${locale}.json`), JSON.stringify(file))
+        writeFileSync(getPath(`${locale}.json`), JSON.stringify(file, null, 2))
       })
     } else {
       config.locales.forEach(locale => {
         let json = getNamespaceJson(locale, name)
         keys.forEach(k => _.unset(json, k))
-        writeFileSync(getPath(locale, name), JSON.stringify(clear(json)))
+        writeFileSync(getPath(locale, name), JSON.stringify(clear(json), null, 2))
       })
     }
 

--- a/src/server/controllers/namespace.controller.ts
+++ b/src/server/controllers/namespace.controller.ts
@@ -97,7 +97,10 @@ export const createNamespace: RequestHandler = (req, res) => {
     // creating the namespace
     if (config.useSingleFile) {
       config.locales.forEach(locale =>
-        writeFileSync(getPath(`${locale}.json`), JSON.stringify({ ...getFileJson(`${locale}.json`), [namespace]: {} }, null, 2))
+        writeFileSync(
+          getPath(`${locale}.json`),
+          JSON.stringify({ ...getFileJson(`${locale}.json`), [namespace]: {} }, null, 2)
+        )
       )
     } else {
       config.locales.forEach(locale => writeFileSync(getPath(locale, name), '{}'))

--- a/src/server/controllers/namespace.controller.ts
+++ b/src/server/controllers/namespace.controller.ts
@@ -97,7 +97,7 @@ export const createNamespace: RequestHandler = (req, res) => {
     // creating the namespace
     if (config.useSingleFile) {
       config.locales.forEach(locale =>
-        writeFileSync(getPath(`${locale}.json`), JSON.stringify({ ...getFileJson(`${locale}.json`), [namespace]: {} }))
+        writeFileSync(getPath(`${locale}.json`), JSON.stringify({ ...getFileJson(`${locale}.json`), [namespace]: {} }, null, 2))
       )
     } else {
       config.locales.forEach(locale => writeFileSync(getPath(locale, name), '{}'))
@@ -137,7 +137,7 @@ export const updateNamespace: RequestHandler = (req, res) => {
         const file = getFileJson(`${locale}.json`)
         file[namespace] = file[oldName]
         delete file[oldName]
-        writeFileSync(getPath(`${locale}.json`), JSON.stringify(file))
+        writeFileSync(getPath(`${locale}.json`), JSON.stringify(file, null, 2))
       })
     } else {
       config.locales.forEach(locale => renameSync(getPath(locale, oldName), getPath(locale, name)))
@@ -170,7 +170,7 @@ export const deleteNamespace: RequestHandler = (req, res) => {
       config.locales.forEach(locale => {
         const file = getFileJson(`${locale}.json`)
         delete file[name]
-        writeFileSync(getPath(`${locale}.json`), JSON.stringify(file))
+        writeFileSync(getPath(`${locale}.json`), JSON.stringify(file, null, 2))
       })
     } else {
       config.locales.forEach(locale => rmSync(getPath(locale, name)))


### PR DESCRIPTION
This PR adds indentation to `JSON.stringify` calls to avoid unreadable json files like:
```json
{"components":{"choose-date":"Select a Date","pick-day":"Please Choose a Day","time":"Time"},"error":{"error":"Error","go-home":"Go to Home","try-again":"Try Again"},"form":{"add-new-address":"Add New Address","add-new-order":"Add a New Order","block":"Block","customer-address":"Customer Address","customer-name":"Customer Name",
```

The output should be like
```json
{
  "components": {
    "choose-date": "Select a Date",
    "pick-day": "Please Choose a Day",
    "time": "Time"
  },
  "error": {
    "error": "Error",
    "go-home": "Go to Home",
    "try-again": "Try Again"
  },
}
```

Later we can detect `indent_size` config from `.edetorconfig`, `prettierrc` or `eslint` config at the initialization process. It can also be an *optional* field at `linguify.config.json`.